### PR TITLE
Do Not Merge: Sample issue: Accessing ThreadLocalStorage from another threads is prohibited

### DIFF
--- a/interaction/src/commonMain/kotlin/com/a65apps/multiplatform/interaction/Store.kt
+++ b/interaction/src/commonMain/kotlin/com/a65apps/multiplatform/interaction/Store.kt
@@ -8,6 +8,7 @@ import com.badoo.reaktive.observable.distinctUntilChanged
 import com.badoo.reaktive.observable.firstOrError
 import com.badoo.reaktive.observable.merge
 import com.badoo.reaktive.observable.subscribe
+import com.badoo.reaktive.observable.threadLocal
 import com.badoo.reaktive.single.map
 import com.badoo.reaktive.subject.publish.PublishSubject
 
@@ -38,6 +39,7 @@ open class Store<S : State, A : Action>(
             .subscribe { states.onNext(it) }
 
         disposable += merge(*middleware.map { it.bind(actions, states) }.toTypedArray())
+            .threadLocal()
             .subscribe { actions.onNext(it) }
     }
 

--- a/interaction/src/commonMain/kotlin/com/a65apps/multiplatform/interaction/todo/TaskMiddleware.kt
+++ b/interaction/src/commonMain/kotlin/com/a65apps/multiplatform/interaction/todo/TaskMiddleware.kt
@@ -13,6 +13,7 @@ import com.badoo.reaktive.observable.Observable
 import com.badoo.reaktive.observable.flatMapSingle
 import com.badoo.reaktive.observable.map
 import com.badoo.reaktive.observable.ofType
+import com.badoo.reaktive.observable.threadLocal
 import com.badoo.reaktive.single.map
 import com.badoo.reaktive.single.onErrorReturn
 import com.badoo.reaktive.single.singleOf
@@ -27,6 +28,7 @@ class TaskLoadMiddleware(
         actions: Observable<TodoAction>,
         state: Observable<TodoState>
     ): Observable<TodoAction> = actions.ofType<TodoAction.Load>()
+        .threadLocal()
         .flatMapSingle {
             taskRepository.allTasks()
                 .subscribeOn(schedulers.io)


### PR DESCRIPTION
Пример ошибки при 2-х threadLocal операторах в цепочке:

```
E/AndroidRuntime: FATAL EXCEPTION: IO, pool-1-thread-1
    Process: com.a65apps.multiplatform.sample, PID: 1500
    java.lang.IllegalStateException: Accessing ThreadLocalStorage from another threads is prohibited. Original thread was (2, main), actual thread is (1512, IO, pool-1-thread-1).
        at com.badoo.reaktive.utils.ThreadLocalHolder.checkCurrentThread(ThreadLocalHolder.kt:51)
        at com.badoo.reaktive.utils.ThreadLocalHolder.get(ThreadLocalHolder.kt:27)
        at com.badoo.reaktive.observable.ThreadLocalKt$threadLocal$$inlined$observable$1$lambda$1.getEmitter(ThreadLocal.kt:37)
        at com.badoo.reaktive.observable.ThreadLocalKt$threadLocal$$inlined$observable$1$lambda$1.getEmitter$default(ThreadLocal.kt:35)
        at com.badoo.reaktive.observable.ThreadLocalKt$threadLocal$$inlined$observable$1$lambda$1.onNext(ThreadLocal.kt:24)
        at com.badoo.reaktive.observable.FlatMapKt$flatMap$$inlined$observable$1$1.onNext(ObservableByEmitter.kt:17)
        at com.badoo.reaktive.observable.SerializedObservableCallbacks.onNext(SerializedObservableCallbacks.kt:34)
        at com.badoo.reaktive.observable.FlatMapObserver$InnerObserver.onNext(Unknown Source:2)
        at com.badoo.reaktive.observable.FlatMapSingleKt$flatMapSingle$$inlined$observable$1$1.onNext(ObservableByEmitter.kt:17)
        at com.badoo.reaktive.observable.SerializedObservableCallbacks.onNext(SerializedObservableCallbacks.kt:34)
        at com.badoo.reaktive.observable.FlatMapSingleKt$flatMapSingle$$inlined$observable$1$lambda$1$1.onSuccess(FlatMapSingle.kt:23)
        at com.badoo.reaktive.single.OnErrorResumeNextKt$onErrorResumeNext$$inlined$single$1$1.onSuccess(SingleByEmitter.kt:17)
        at com.badoo.reaktive.single.OnErrorResumeNextKt$onErrorResumeNext$$inlined$single$1$lambda$1$2.onSuccess(Unknown Source:2)
        at com.badoo.reaktive.single.VariousKt$singleOf$$inlined$singleUnsafe$1.subscribe(Various.kt:52)
        at com.badoo.reaktive.single.VariousKt$singleOf$$inlined$singleUnsafe$1.subscribe(Various.kt:6)
        at com.badoo.reaktive.base.SubscribeSafeKt.subscribeSafe(SubscribeSafe.kt:7)
        at com.badoo.reaktive.single.OnErrorResumeNextKt$onErrorResumeNext$$inlined$single$1$lambda$1.onError(OnErrorResumeNext.kt:20)
        at com.badoo.reaktive.single.MapKt$map$$inlined$single$1$1.onError(SingleByEmitter.kt:23)
        at com.badoo.reaktive.single.MapKt$map$$inlined$single$1$lambda$1.onError(Unknown Source:7)
        at com.badoo.reaktive.single.SubscribeOnKt$subscribeOn$$inlined$single$1$1.onError(SingleByEmitter.kt:23)
        at com.badoo.reaktive.single.SubscribeOnKt$subscribeOn$$inlined$single$1$lambda$1$1.onError(Unknown Source:7)
        at com.badoo.reaktive.rxjavainterop.SingleKt$asRxJava2$2.onError(Single.kt:51)
        at io.reactivex.internal.operators.single.SingleMap$MapSingleObserver.onError(SingleMap.java:69)
        at io.reactivex.internal.operators.observable.ObservableSingleSingle$SingleElementObserver.onError(ObservableSingleSingle.java:93)
        at retrofit2.adapter.rxjava2.BodyObservable$BodyObserver.onError(BodyObservable.java:72)
        at retrofit2.adapter.rxjava2.CallExecuteObservable.subscribeActual(CallExecuteObservable.java:56)
        at io.reactivex.Observable.subscribe(Observable.java:12268)
        at retrofit2.adapter.rxjava2.BodyObservable.subscribeActual(BodyObservable.java:34)
        at io.reactivex.Observable.subscribe(Observable.java:12268)
        at io.reactivex.internal.operators.observable.ObservableSingleSingle.subscribeActual(ObservableSingleSingle.java:35)
        at io.reactivex.Single.subscribe(Single.java:3603)
        at io.reactivex.internal.operators.single.SingleMap.subscribeActual(SingleMap.java:34)
        at io.reactivex.Single.subscribe(Single.java:3603)
        at com.badoo.reaktive.rxjavainterop.SingleKt$asReaktive$$inlined$singleUnsafe$1.subscribe(Various.kt:48)
        at com.badoo.reaktive.rxjavainterop.SingleKt$asReaktive$$inlined$singleUnsafe$1.subscribe(Various.kt:6)
        at com.badoo.reaktive.base.SubscribeSafeKt.subscribeSafe(SubscribeSafe.kt:7)
        at com.badoo.reaktive.single.SubscribeOnKt$subscribeOn$$inlined$single$1$lambda$1.invoke(SubscribeOn.kt:17)
2020-02-12 07:32:14.296 1500-1538/com.a65apps.multiplatform.sample E/AndroidRuntime:     at com.badoo.reaktive.single.SubscribeOnKt$subscribeOn$$inlined$single$1$lambda$1.invoke(Unknown Source:0)
        at com.badoo.reaktive.scheduler.ExecutorServiceScheduler$ExecutorImpl$Companion$wrapSchedulerTaskSafe$1.run(ExecutorServiceScheduler.kt:102)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:462)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:301)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
```